### PR TITLE
Added a close() function to discovery

### DIFF
--- a/samsung-discovery.js
+++ b/samsung-discovery.js
@@ -115,9 +115,6 @@ SamsungDiscovery.prototype.listen = function() {
     self.timer = setInterval(notify, 30 * 1000);
     notify();
   });
-  ssdp.on('error', function(e) {
-    console.log('Theres an error');
-  });
 };
 
 SamsungDiscovery.prototype.close = function() {
@@ -126,6 +123,7 @@ SamsungDiscovery.prototype.close = function() {
   if (self.ssdp) {
     self.ssdp.close();
     clearTimeout(self.timer);
+    delete self.timer;
     delete self.ssdp;
   }
 }

--- a/samsung-discovery.js
+++ b/samsung-discovery.js
@@ -1,18 +1,18 @@
 /*jslint node: true */
 "use strict";
-var Emitter        = require('events').EventEmitter, 
-    os             = require('os'), 
-    util           = require('util'), 
-    SSDP           = require('node-ssdp'), 
-    netmask        = require('netmask'), 
+var Emitter        = require('events').EventEmitter,
+    os             = require('os'),
+    util           = require('util'),
+    SSDP           = require('node-ssdp'),
+    netmask        = require('netmask'),
     Device         = require('./samsung-airconditioner');
 
 
-var DEFAULT_LOGGER = { 
-  error   : function(msg, props) { console.log(msg); if (!!props) console.trace(props.exception); }, 
-  warning : function(msg, props) { console.log(msg); if (!!props) console.log(props);             }, 
-  notice  : function(msg, props) { console.log(msg); if (!!props) console.log(props);             }, 
-  info    : function(msg, props) { console.log(msg); if (!!props) console.log(props);             }, 
+var DEFAULT_LOGGER = {
+  error   : function(msg, props) { console.log(msg); if (!!props) console.trace(props.exception); },
+  warning : function(msg, props) { console.log(msg); if (!!props) console.log(props);             },
+  notice  : function(msg, props) { console.log(msg); if (!!props) console.log(props);             },
+  info    : function(msg, props) { console.log(msg); if (!!props) console.log(props);             },
   debug   : function(msg, props) { console.log(msg); if (!!props) console.log(props);             }
 };
 
@@ -35,10 +35,10 @@ var SamsungDiscovery = function(options) {
 
   ifaces = os.networkInterfaces();
   for (ifname in ifaces) {
-    if ((!ifaces.hasOwnProperty(ifname)) || 
-        (ifname.indexOf('vmnet') === 0)  || 
-        (ifname.indexOf('vboxnet') === 0)  || 
-        (ifname.indexOf('vnic') === 0)   || 
+    if ((!ifaces.hasOwnProperty(ifname)) ||
+        (ifname.indexOf('vmnet') === 0)  ||
+        (ifname.indexOf('vboxnet') === 0)  ||
+        (ifname.indexOf('vnic') === 0)   ||
         (ifname.indexOf('tun') !== -1)) {
       continue;
     }
@@ -49,27 +49,41 @@ var SamsungDiscovery = function(options) {
     for (ifa = 0; ifa < ifaddrs.length; ifa++) {
       if ((ifaddrs[ifa].internal) || (ifaddrs[ifa].family !== 'IPv4')) continue;
 
-      self.logger.debug('listening', { 
-        network_interface: ifname, 
-        ipaddr: ifaddrs[ifa].address, 
-        portno: 1900 
+      self.logger.debug('listening', {
+        network_interface: ifname,
+        ipaddr: ifaddrs[ifa].address,
+        portno: 1900
       });
-      self.listen(ifname, ifaddrs[ifa].address, 1900);
+
+      self.ifname = ifname;
+      self.ipaddr = ifaddrs[ifa].address;
+      self.portno = 1900;
+      self.listen();
     }
   }
 };
 util.inherits(SamsungDiscovery, Emitter);
 
-SamsungDiscovery.prototype.listen = function(ifname, ipaddr, portno) {
+SamsungDiscovery.prototype.listen = function() {
   var self = this;
 
+  if (self.ssdp) {
+    self.logger.error('discovery', {
+      event: 'listen',
+      diagnostic: 'error',
+      exception: 'already listening'
+    });
+    //self.emit('error', 'already listening');
+    return;
+  }
+
   var notify = function() {
-    ssdp.notify(ifname, ipaddr, portno, 'AIR CONDITIONER',
+    ssdp.notify(self.ifname, self.ipaddr, self.portno, 'AIR CONDITIONER',
                 { SPEC_VER: 'MSpec-1.00', SERVICE_NAME: 'ControlServer-MLib', MESSAGE_TYPE: 'CONTROLLER_START' });
   };
 
-  var ssdp = new SSDP({
-    addMembership     : false, 
+  var ssdp = self.ssdp = new SSDP({
+    addMembership     : false,
     responsesOnly     : true,
     multicastLoopback : false,
     noAdvertisements  : true
@@ -85,7 +99,7 @@ SamsungDiscovery.prototype.listen = function(ifname, ipaddr, portno) {
     }
 
     mac = info.MAC_ADDR;
-    self.devices[mac] = new Device({ 
+    self.devices[mac] = new Device({
       logger : self.logger,
       ip     : rinfo.address,
       duid   : mac,
@@ -98,11 +112,23 @@ SamsungDiscovery.prototype.listen = function(ifname, ipaddr, portno) {
 
   ssdp.server('0.0.0.0');
   ssdp.sock.on('listening', function() {
-    setInterval(notify, 30 * 1000);
+    self.timer = setInterval(notify, 30 * 1000);
     notify();
+  });
+  ssdp.on('error', function(e) {
+    console.log('Theres an error');
   });
 };
 
+SamsungDiscovery.prototype.close = function() {
+  var self = this;
+
+  if (self.ssdp) {
+    self.ssdp.close();
+    clearTimeout(self.timer);
+    delete self.ssdp;
+  }
+}
 
 SSDP.prototype.notify = function(ifname, ipaddr, portno, signature, vars) {/* jshint unused: false */
   var out;
@@ -115,9 +141,9 @@ SSDP.prototype.notify = function(ifname, ipaddr, portno, signature, vars) {/* js
     var bcast, mask, quad0;
 
     var udn   = self.usns[usn],
-        heads ={ 
-          HOST            : '239.255.255.250:1900', 
-          'CACHE-CONTROL' : 'max-age=20', 
+        heads ={
+          HOST            : '239.255.255.250:1900',
+          'CACHE-CONTROL' : 'max-age=20',
           SERVER          : signature
         };
 
@@ -129,10 +155,10 @@ SSDP.prototype.notify = function(ifname, ipaddr, portno, signature, vars) {/* js
 
 // TBD: use the (obsolete) class A/B/C netmasks
     bcast = new netmask.Netmask(ipaddr + '/' + mask).broadcast;
-    self.logger.debug('multicasting', { 
-      network_interface: ifname, 
-      ipaddr: bcast, 
-      portno: 1900 
+    self.logger.debug('multicasting', {
+      network_interface: ifname,
+      ipaddr: bcast,
+      portno: 1900
     });
 
     out = new Buffer(out);


### PR DESCRIPTION
Why? because the listener will not quit automatically, and it's impossible to add an external timeout otherwise.

You can choose to listen/close again and again, which should work as expected.
